### PR TITLE
use "pkgdown" solution to publish

### DIFF
--- a/.github/workflows/quarto-gh-pages-html.yaml
+++ b/.github/workflows/quarto-gh-pages-html.yaml
@@ -28,11 +28,12 @@ jobs:
       - name: Render Quarto Project
         uses: quarto-dev/quarto-actions/render@v2
         
-      - name: Publish to GitHub Pages
+      - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: quarto-dev/quarto-actions/publish@v2
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
-          render: false
-          target: gh-pages
+          clean: true
+          branch: gh-pages
+          folder: _site
         
         


### PR DESCRIPTION
another attempt to fix #11, as the quarto action ran into problems

also, I deleted the pages environment, it seems a different way of doing things than pushing to `gh-pages`.

in the fullness of time, I think using a pages environment could be a cleaner way of doing things; I think we would have to:

- once we render, if not a pull-request, zip up the `_site` folder and upload it as an artifact
- have the environment fetch the artifact and deploy it